### PR TITLE
Use relative paths for build directories in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target
-/result
+target
+result


### PR DESCRIPTION
This ensures that build directories on any directory level are ignored.